### PR TITLE
Read text with unicode encoding

### DIFF
--- a/build_vocab.py
+++ b/build_vocab.py
@@ -14,7 +14,7 @@ def build_word2id(seq_path, min_word_count):
     Returns:
         word2id: Dictionary; word-to-id dictionary
     """
-    sequences = open(seq_path).readlines()
+    sequences = open(seq_path, encoding='utf8').readlines()
     num_seqs = len(sequences)
     counter = Counter()
     

--- a/data_loader.py
+++ b/data_loader.py
@@ -8,8 +8,8 @@ class Dataset(data.Dataset):
     """Custom data.Dataset compatible with data.DataLoader."""
     def __init__(self, src_path, trg_path, src_word2id, trg_word2id):
         """Reads source and target sequences from txt files."""
-        self.src_seqs = open(src_path).readlines()
-        self.trg_seqs = open(trg_path).readlines()
+        self.src_seqs = open(src_path, encoding='utf8').readlines()
+        self.trg_seqs = open(trg_path, encoding='utf8').readlines()
         self.num_total_seqs = len(self.src_seqs)
         self.src_word2id = src_word2id
         self.trg_word2id = trg_word2id


### PR DESCRIPTION
Fix unicode error.
```

  File "build_vocab.py", line 17, in build_word2id
    sequences = open(seq_path).readlines()
UnicodeDecodeError: 'cp950' codec can't decode byte 0xc3 in position 4026: illegal multibyte sequence

```